### PR TITLE
feat: Export AWS_DEFAULT_REGION too with selaws script

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ echo "export PATH=\"\${PATH}:$(pwd)/bin\"" >> ~/.bashrc
 By adding this to your path, you can run
 ```
 ad-aws-login  # to run the script
-. selaws      # to export AWS_PROFILE to your session
+. selaws      # to export AWS_PROFILE and AWS_DEFAULT_REGION to your session
 ```
 
 ## Example

--- a/bin/selaws
+++ b/bin/selaws
@@ -15,6 +15,18 @@ function _selaws() {
     fi
 }
 
-export AWS_PROFILE="$(_selaws)"
+function region() {
+    local _aws_profile="$1"
+    readonly PROFILE_CONFIG="$(sed -n "/${_aws_profile}/,/^ *$/p" "${AWS_CONFIG_FILE}")"
+    
+    local region=""
+    [[ -z "${region}" ]] && region=$(echo "${PROFILE_CONFIG}" |  (grep 'region=.*' || true) | sed -E 's/^.*region *= *([^ ]*).*$/\1/')
+    echo $region
+}
+
+aws_profile="$(_selaws)"
+export AWS_PROFILE="${aws_profile}"
+region=$(region "${aws_profile}")
+export AWS_DEFAULT_REGION="${region}"
 
 # vim: syntax=sh


### PR DESCRIPTION
Add the export of AWS_DEFAULT_REGION based on the config file settings. This environment variable is needed by the aws-sdk.