### PR TITLE
Fixed selaws script to support AWS SSO profiles in config file

### DIFF
--- a/bin/selaws
+++ b/bin/selaws
@@ -20,7 +20,7 @@ function region() {
     readonly PROFILE_CONFIG="$(sed -n "/${_aws_profile}/,/^ *$/p" "${AWS_CONFIG_FILE}")"
     
     local region=""
-    [[ -z "${region}" ]] && region=$(echo "${PROFILE_CONFIG}" |  (grep 'region=.*' || true) | sed -E 's/^.*region *= *([^ ]*).*$/\1/')
+    [[ -z "${region}" ]] && region=$(echo "${PROFILE_CONFIG}" |  (grep '\<region=.*\>' || true) | sed -E 's/^region *= *([^ ]*).*$/\1/')
     echo $region
 }
 


### PR DESCRIPTION
Selaws script applied multiple regions to env variables if there was two region parameters in ~/.aws/config file:
```
region=eu-west-1
sso_region=eu-west-1
```
Fixed script's regexp to select only `region` from beginning of line.