### PR TITLE
fix: update README with troubleshooting tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Azure AD Login to AWS
 
-The `ad-aws-login` script fetches temporary AWS credentials with Azude AD
+The `ad-aws-login` script fetches temporary AWS credentials with Azure AD
 login (https://myapps.microsoft.com).
 
 So far this has been used **only on OS X** and with **Google Chrome** and **Microsoft Edge**.
@@ -133,7 +133,12 @@ you must export AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE variables.
 
 ## Useful commands
 
-If you have [fzf](https://github.com/junegunn/fzf) installed, `aws-aws-login` will use it automatically for better experience.
+If you have [fzf](https://github.com/junegunn/fzf) installed, `ad-aws-login` will use it automatically for better experience.
+
+## Troubleshooting
+
+- [`myapps.microsoft.com`](myapps.microsoft.com) does not render, the screen is blank
+   - Delete the `user_data` folder in the root of `ad-aws-login` repository and try again
 
 ## More Resouces
 


### PR DESCRIPTION
I've encountered an issue where `ad-aws-login` would open the browser, but [`myapps.microsoft.com`](myapps.microsoft.com) wouldn't render, the screen would just be blank:

<img width="400" alt="Screenshot 2023-03-09 at 16 08 22" src="https://user-images.githubusercontent.com/24512922/224243807-e87bef39-6b0a-447c-b2a9-8156e3d702c0.png">

Some other people have encountered this issue as well and the solution seems to be to delete the `user_data` folder and try again.

This MR adds that tip to the README to speed up troubleshooting in the future. It also fixes a few typos in the README.
